### PR TITLE
RabbitMQ.Publish - Bug fix for Memory Cache

### DIFF
--- a/Frends.RabbitMQ.Publish/CHANGELOG.md
+++ b/Frends.RabbitMQ.Publish/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.4.0] - 2024-09-12
+### Fixed
+- Fixed issue with MemoryCache error `Index was outside the bounds of the array` by adding try - catch block and changing how cache key is formatted.
+
 ## [1.3.0] - 2024-09-06
 ### Fixed
 - Fixed issue with simultaneous calls by storing connections to Memory.Cache.

--- a/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish.csproj
+++ b/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.3.0</Version>
+	<Version>1.4.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Publish.cs
+++ b/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Publish.cs
@@ -262,6 +262,7 @@ public class RabbitMQ
         return key;
     }
 
+    [ExcludeFromCodeCoverage]
     private static string GetCacheKeyFromMemoryCache(string cacheKey)
     {
         try

--- a/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Publish.cs
+++ b/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Publish.cs
@@ -230,7 +230,7 @@ public class RabbitMQ
             try
             {
                 var rabbitMQConnection = new RabbitMQConnection { AMQPConnection = factory.CreateConnection() };
-                RabbitMQConnectionCache.Add($"{Guid.NewGuid()}_{cacheKey}", rabbitMQConnection, new CacheItemPolicy() { RemovedCallback = RemovedCallback, SlidingExpiration = TimeSpan.FromSeconds(connection.ConnectionExpirationSeconds) });
+                RabbitMQConnectionCache.Add($"{cacheKey}_{Guid.NewGuid()}", rabbitMQConnection, new CacheItemPolicy() { RemovedCallback = RemovedCallback, SlidingExpiration = TimeSpan.FromSeconds(connection.ConnectionExpirationSeconds) });
                 return rabbitMQConnection.AMQPConnection;
             }
             catch (Exception ex)
@@ -248,6 +248,7 @@ public class RabbitMQ
         return null;
     }
 
+    [ExcludeFromCodeCoverage]
     private static string GetCacheKey(Connection connection)
     {
         var key = $"{connection.Host}:";

--- a/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Publish.cs
+++ b/Frends.RabbitMQ.Publish/Frends.RabbitMQ.Publish/Publish.cs
@@ -264,6 +264,10 @@ public class RabbitMQ
 
     private static string GetCacheKeyFromMemoryCache(string cacheKey)
     {
-        return RabbitMQConnectionCache.ToList().Where(e => e.Key.Split("_")[1] == cacheKey).Select(e => e.Key).FirstOrDefault();
+        try
+        {
+            return RabbitMQConnectionCache.ToList().Where(e => e.Key.Split("_")[0] == cacheKey).Select(e => e.Key).FirstOrDefault();
+        }
+        catch { return null; }
     }
 }


### PR DESCRIPTION
#17 

## [1.4.0] - 2024-09-12
### Fixed
- Fixed issue with MemoryCache error `Index was outside the bounds of the array` by adding try - catch block and changing how cache key is formatted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Version 1.4.0 of the RabbitMQ Publish module released, enhancing caching mechanisms.

- **Bug Fixes**
	- Resolved an error related to MemoryCache, improving application stability during edge cases.

- **Documentation**
	- Updated changelog to reflect the new version and changes made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->